### PR TITLE
redirect to sign-up with invite code

### DIFF
--- a/client/sso.js
+++ b/client/sso.js
@@ -53,12 +53,15 @@ Template.loginLayout.created = function () {
     }
     return Meteor.loginUsingLearnersGuildJWT(lgJWT)
   }
-  console.log('[LG SSO] no lgJWT token found in query string, redirecting to IDM')
   // differentiate between dev and prod
   const idmURL = window.location.href.match(/learnersguild\.dev/) ? 'http://idm.learnersguild.dev' : 'https://idm.learnersguild.org'
-  const redirect = encodeURIComponent(window.location.href)
-  console.log('[LG SSO] idmURL:', idmURL, 'redirect:', redirect)
-  window.location.href = `${idmURL}/sign-in?redirect=${redirect}&responseType=token`
+  const redirect = encodeURIComponent(window.location.href.split(/[?#]/)[0])
+  /* global HttpQueryString */
+  const {inviteCode} = HttpQueryString.parse(window.location.search.slice(1))
+  const authURLQuery = HttpQueryString.stringify({redirect, responseType: 'token'})
+  const authURL = inviteCode ? `${idmURL}/sign-up/${inviteCode}?${authURLQuery}` : `${idmURL}/sign-in?${authURLQuery}`
+  console.log(`[LG SSO] no lgJWT token found in query string, redirecting to ${authURL}`)
+  window.location.href = authURL
 }
 
 // make sure our lgSSO service data is returned with user object

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'learnersguild:rocketchat-lg-sso',
-  version: '0.4.9',
+  version: '0.5.0',
   summary: 'Accounts login handler for Learners Guild SSO.',
   git: 'https://github.com/LearnersGuild/rocketchat-lg-sso'
 })
@@ -12,6 +12,7 @@ Package.onUse(function (api) {
   api.use([
     'ecmascript',
     'deepwell:raven@0.3.0',
+    'evaisse:http-query-string@0.0.1',
   ])
   api.use([
     'rocketchat:lib@0.0.1'

--- a/package.js
+++ b/package.js
@@ -5,7 +5,8 @@ Package.describe({
   git: 'https://github.com/LearnersGuild/rocketchat-lg-sso'
 })
 
-Package.onUse(function(api) {
+/* eslint-disable prefer-arrow-callback */
+Package.onUse(function (api) {
   api.versionsFrom('1.2.1')
 
   api.use([
@@ -14,7 +15,7 @@ Package.onUse(function(api) {
   ])
   api.use([
     'rocketchat:lib@0.0.1'
-  ], { weak: true, unordered: false })
+  ], {weak: true, unordered: false})
   api.use([
     'templating'
   ], 'client')

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "HTTP",
       "Meteor",
       "Npm",
+      "Package",
       "Random",
       "RavenLogger",
       "RocketChat",


### PR DESCRIPTION
Fixes #17.

This makes new player on-boarding flow much more seamless. It allows us to send new players a url like:

https://chat.learnersguild.org/home?inviteCode=oakland-2016-july

Then, the player will be redirected to:

https://idm.learnersguild.org/sign-up/oakland-2016-july?redirect=...&responseType=token

... instead of:

https://idm.learnersguild.org/sign-in?redirect=...&responseType=token
