### PR TITLE
gracefully recover from the lack of a gravatar

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+#### 0.5.8
+- Be more defensive when trying to set avatar from gravatar. (Fixes #24.)
+
 #### 0.5.7
 - Be more defensive when reading the Meteor user record and handle errors gracefully. (Fixes #16, #21, and #22.)
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'learnersguild:rocketchat-lg-sso',
-  version: '0.5.7',
+  version: '0.5.8',
   summary: 'Accounts login handler for Learners Guild SSO.',
   git: 'https://github.com/LearnersGuild/rocketchat-lg-sso'
 })


### PR DESCRIPTION
Fixes #24.
1. Set the default to an initials image URL (from our initials service).
2. Ensure that non-fatal errors do not hinder the authentication process. For example, joining default rooms, setting the avatar, etc. The only things that should fail the sign-in process are (a) token errors, and (b) low-level Meteor / MongoDB errors.
